### PR TITLE
Stop nginx before updating

### DIFF
--- a/update-gitlab-omnibus.sh
+++ b/update-gitlab-omnibus.sh
@@ -60,6 +60,9 @@ gitlab-ctl stop unicorn
 # Stop Sidekiq
 gitlab-ctl stop sidekiq
 
+# If you are upgrading from 7.3.0
+sudo gitlab-ctl stop nginx
+
 # Create a backup
 gitlab-rake gitlab:backup:create
 


### PR DESCRIPTION
After 7.3.0 the gitlab update guide recommends stopping nginx before updating

https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/update.md#updating-from-gitlab-6-6-x-and-higher-to-the-latest-version
