### PR TITLE
Update GitLab the 7.10 way

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Introduction:
 
 This is just a small script to update an existing Gitlab instance to a newer version. Basically it just executes the commands from the Gitlab documentation, but in an automated way (hint: automation).
 
-This is tested on Ubuntu 14.04 with GiLab Omnibus 7.3.x
+This is tested on Ubuntu 14.04 with GiLab Omnibus ~7.3
 
 How to update GitLab?
 ---------------------

--- a/update-gitlab-omnibus.sh
+++ b/update-gitlab-omnibus.sh
@@ -32,7 +32,7 @@ fi
 
 
 # Check which version is installed locally.
-installedVersion=$( dpkg -s gitlab|grep Version|cut -d\: -f2|sed 's/\ //g' )
+installedVersion=$( (dpkg -s gitlab-ce 2>/dev/null || dpkg -s gitlab) | grep '^Version' | cut -d\: -f2 |sed 's/\ //g' )
 if [ $? -eq 0 ]; then
 	echo -e $COL_GREEN"Currently installed version is: ${installedVersion}"$COL_RESET
 else
@@ -53,28 +53,9 @@ fi
 # Download the file
 wget ${downloadUrl}
 
-
-# Stop Unicorn Service
-gitlab-ctl stop unicorn
-
-# Stop Sidekiq
-gitlab-ctl stop sidekiq
-
-# Stop Nginx
-gitlab-ctl stop nginx
-
-# Create a backup
-gitlab-rake gitlab:backup:create
-
-
 # Install the new version
 dpkg -i ${fileName}
 
-# Re-Configure GitLab
-gitlab-ctl reconfigure
-
-# Restart Services
-gitlab-ctl restart
 
 # Remove downloaded .deb file
 rm ${fileName}


### PR DESCRIPTION
In the 7.10 package the `gitlab-ctl upgrade` command executes the removed commands.  See https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/update.md#updating-from-gitlab-6-6-and-higher-to-7-10-or-newer
